### PR TITLE
catch base64 decoding errors and log warning message

### DIFF
--- a/bofhound/ad/adds.py
+++ b/bofhound/ad/adds.py
@@ -46,9 +46,10 @@ class ADDS():
             schemaIdGuid = object.get(ADDS.AT_SCHEMAIDGUID, None)
             if schemaIdGuid:
                 new_schema = BloodHoundSchema(object)
-                self.schemas.append(new_schema)
-                if new_schema.Name not in self.ObjectTypeGuidMap.keys():
-                    self.ObjectTypeGuidMap[new_schema.Name] = new_schema.SchemaIdGuid
+                if new_schema.SchemaIdGuid is not None:
+                    self.schemas.append(new_schema)
+                    if new_schema.Name not in self.ObjectTypeGuidMap.keys():
+                        self.ObjectTypeGuidMap[new_schema.Name] = new_schema.SchemaIdGuid
                 continue
 
             accountType = int(object.get(ADDS.AT_SAMACCOUNTTYPE, 0))
@@ -371,7 +372,11 @@ class ADDS():
         if not entry.RawAces:
             return 0
 
-        value = base64.b64decode(entry.RawAces)
+        try:
+            value = base64.b64decode(entry.RawAces)
+        except:
+            logging.warning(f'Error base64 decoding nTSecurityDescriptor attribute on {entry._entry_type} {entry.Properties["name"]}')
+            return 0
 
         if not value:
             return 0

--- a/bofhound/ad/models/bloodhound_schema.py
+++ b/bofhound/ad/models/bloodhound_schema.py
@@ -11,5 +11,8 @@ class BloodHoundSchema(object):
 
 		if 'name' in object.keys() and 'schemaidguid' in object.keys():
 			self.Name = object.get('name').lower()
-			self.SchemaIdGuid = str(UUID(bytes_le=base64.b64decode(object.get('schemaidguid')))).lower()
-			logging.debug(f"Reading Schema object {ColorScheme.schema}{self.Name}[/]", extra=OBJ_EXTRA_FMT)
+			try:
+				self.SchemaIdGuid = str(UUID(bytes_le=base64.b64decode(object.get('schemaidguid')))).lower()
+				logging.debug(f"Reading Schema object {ColorScheme.schema}{self.Name}[/]", extra=OBJ_EXTRA_FMT)
+			except:
+				logging.warning(f"Error base64 decoding SchemaIDGUID attribute on Schema {ColorScheme.schema}{self.Name}[/]", extra=OBJ_EXTRA_FMT)


### PR DESCRIPTION
This PR catches and logs errors in the event `nTSecurityDescriptor` or `schemaIdGuid` attributes aren't base64 encoded